### PR TITLE
fixed fa white and black icons, fixed photos above gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+  <div class="header">
   <title>UW Seal</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -24,6 +25,7 @@
     integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
     crossorigin="anonymous">
     </script>
+  </div>
 </head>
 
 <body>
@@ -47,8 +49,8 @@
       <!-- Right-sided navbar links -->
       <div class="d-none d-md-flex justify-content-center flex-wrap"
         style="margin-right: auto; margin-left: auto; font-size: large; display: flex; justify-content: center; width: 60em;">
-        <a href="#about" class="w3-button rounded">ABOUT</a>
-        <a href="#team" class="w3-button rounded"><i class="fa fa-user"></i>
+        <a href="#about" class="w3-button rounded"><i class="fa fa-user"></i>ABOUT</a>
+        <a href="#team" class="w3-button rounded"><i class="fa fa-users"></i>
           TEAM</a>
         <a href="#work" class="w3-button rounded"><i class="fa fa-th"></i>
           WORK</a>
@@ -1191,13 +1193,6 @@
   <section class="w3-light-grey" id="gallery">
     <h3 class="w3-center">GALLERY</h3>
 
-    <div style="display: flex" id="gallery-thumbnails">
-      <img id="spr17-thumbnail" class="cursor"
-        src="images/gallery/spring17/thumbnail.jpg">
-      <img id="spr18-thumbnail" class="cursor"
-        src="images/gallery/spring18/thumbnail.jpg">
-    </div>
-
     <div id="spr17-gallery">
       <div class="mySlides">
         <div class="numbertext">1 / 13</div>
@@ -1356,7 +1351,9 @@
   </section>
 
   <!-- Footer. This section contains an ad for W3Schools Spaces. You can leave it to support us. -->
+  
   <footer class="w3-center w3-black w3-padding-64">
+  <div class="footer">
     <a href="#home" class="w3-button w3-light-grey"><i
         class="fa fa-arrow-up w3-margin-right"></i>To the top</a>
     <div class="w3-xlarge w3-section">
@@ -1373,7 +1370,9 @@
         <i class="fa fa-linkedin" aria-hidden="true"></i>
       </a>
     </div>
+  </div>
   </footer>
+
 
   <script src="showcaseAction.js"></script>
   <script src="main.js"></script>

--- a/style.css
+++ b/style.css
@@ -183,5 +183,13 @@ figcaption {
 /* Social Media Icon Color */
 
 .fa {
-  color:white
+  color:black
+}
+
+.footer .fa{
+  color: white
+}
+
+.header .fa{
+  color: black
 }


### PR DESCRIPTION
I fixed the fa icons so the header or footer has white icons while the body has black colored icons. I also added an icon for the about tab and changed the icon at the team tab in the navigation links at the top of the page. The photos above the gallery is also gone